### PR TITLE
[Leo] Make return types optional

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -438,7 +438,7 @@ decrement-statement =
     %s"decrement" "(" identifier "," expression "," expression [ "," ] ")" ";"
 
 function-declaration = *annotation %s"function" identifier
-                       "(" [ function-parameters ] ")" "->" type
+                       "(" [ function-parameters ] ")" [ "->" type ]
                        block
 
 function-parameters = function-parameter *( "," function-parameter ) [ "," ]
@@ -447,11 +447,11 @@ function-parameter = [ %s"public" / %s"constant" / %s"const" ]
                      identifier ":" type
 
 transition-declaration = *annotation %s"transition" identifier
-                         "(" [ function-parameters ] ")" "->" type
+                         "(" [ function-parameters ] ")" [ "->" type ]
                          block [ finalizer ]
 
 finalizer = %s"finalize" identifier
-            "(" [ function-parameters ] ")" "->" type
+            "(" [ function-parameters ] ")" [ "->" type ]
             block
 
 struct-declaration = %s"struct" identifier


### PR DESCRIPTION
It's possible for functions, transitions and finalizers to not have return values.

In Aleo grammar,

```abnf
function = cws %s"function" ws identifier ws ":"
           *function-input
           1*instruction
           *function-output ;;; <--
; ...
transition = cws %s"transition" ws identifier ws ":"
           *transition-input
           *instruction
           *transition-output ;;; <--
; ...
finalize = cws %s"finalize" ws identifier ws ":"
           *finalize-input
           1*command
           *finalize-output;;; <--
```
