### PR TITLE
[Aleo] Tweak rule for identifiers.

### DIFF
--- a/aleo.abnf
+++ b/aleo.abnf
@@ -137,7 +137,7 @@ hex-digit = digit / "a" / "b" / "c" / "d" / "e" / "f" ; 0-9 A-F a-f
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-identifier = 1*letter *( letter / digit / "_" )
+identifier = letter *( letter / digit / "_" )
 
 program-id = identifier "." identifier
 


### PR DESCRIPTION
The previous version
```
identifier = 1*letter *( letter / ... )
```

is purposely derived from the nom parser, which uses `alpha1` (i.e. one or more ASCII alphabetical characters) for `1*letter` above.

However, the rule is technically ambiguous, because there may be multiple ways to divide the initial letters of an identifier betweeen the `1*letter` part and the `*( letter / ... )` part (e.g. `abc` can be organized either as `a` then `bc` or as `ab` then `c`).

There is nothing wrong in the nom parser, which disambiguates the situation by parsing as many letters as possible via `alpha1`, which is a form of extra-grammatical disambiguation.

While we could disambiguate the ABNF grammar rule via an extra-grammatical predicate, it is simpler to make the rule non-ambiguous (also for formal verification purposes), which this commit does.

If nom provided an `alpha` that parses exactly one ASCII alphabetic character, I would have also proposed a PR to the nom parser to use that instead of `alpha1`, to keep grammar and parser as aligned as possible. However, nom does not appear to provide such an `alpha` (i.e. exactly one), but only `alpha0` (zero or more) and `alpha1` (one or more). We could of course write code to parse exactly one letter using nom, but it doesn't seem worth complicating that code. So, all in all, it seems best to leave the parser as is, and to have this very minor difference in the form of the grammar rule. However, note that the grammar rule and the parser are equivalent, in the sense that they recognize exactly the same identifiers; it's just a slightly different formulation.