### PR TITLE
Make finalizer block return type be optional.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -451,7 +451,8 @@ transition-declaration = *annotation %s"transition" identifier
                          block [ finalizer ]
 
 finalizer = %s"finalize" identifier
-            "(" [ function-parameters ] ")" "->" type
+            "(" [ function-parameters ] ")"
+            [ "->" type ]
             block
 
 struct-declaration = %s"struct" identifier


### PR DESCRIPTION
See https://github.com/AleoHQ/grammars/pull/7  
In practice so far there are no return types for finalizer blocks in the Leo workshop examples, so this change makes the grammar consistent with those.
