### PR TITLE
[Aleo] Remove a layer in the grammar formulation.

### DIFF
--- a/aleo.abnf
+++ b/aleo.abnf
@@ -259,21 +259,21 @@ literal-type = arithmetic-type / address-type / boolean-type / string-type
 
 plaintext-type = literal-type / identifier
 
-value-type = ( plaintext-type %s".constant"
-             / plaintext-type %s".public"
-             / plaintext-type %s".private"
-             / identifier %s".record"
-             / locator %s".record" )
+value-type = plaintext-type %s".constant"
+           / plaintext-type %s".public"
+           / plaintext-type %s".private"
+           / identifier %s".record"
+           / locator %s".record"
 
-finalize-type = ( plaintext-type %s".public"
-                / identifier %s".record"
-                / locator %s".record" )
+finalize-type = plaintext-type %s".public"
+              / identifier %s".record"
+              / locator %s".record"
 
 entry-type = plaintext-type ( %s".constant" / %s".public" / %s".private" )
 
-register-type = ( locator %s".record"
-                / identifier %s".record"
-                / plaintext-type )
+register-type = locator %s".record"
+              / identifier %s".record"
+              / plaintext-type
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This does not change the language defined by the grammar. It only optimizes a few rules to avoid an extra group layer `( ... )`, which is presumably a leftover from a time in which it was preceded by some whitespace and/or comments. The presence or absence of the layer are equivalent for most purposes, but they lead to slightly different CSTs.