### PR TITLE
[Leo] Add the unit type and expression.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -319,7 +319,7 @@ function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 
 unit-expression = "(" ")"
 
-tuple-expression = "(" [ expression 1*( "," expression ) [ "," ] ] ")"
+tuple-expression = "(" expression 1*( "," expression ) [ "," ] ")"
 
 struct-expression = identifier "{" struct-component-initializer
                                    *( "," struct-component-initializer )

--- a/leo.abnf
+++ b/leo.abnf
@@ -273,15 +273,20 @@ address-type = %s"address"
 
 string-type = %s"string"
 
-primitive-type =  boolean-type / arithmetic-type / address-type / string-type
+named-primitive-type =
+    boolean-type / arithmetic-type / address-type / string-type
 
-named-type = primitive-type
+unit-type = "(" ")"
+
+primitive-type = named-primitive-type / unit-type
+
+named-type = named-primitive-type
            / identifier [ "." %s"record" ]
            / locator [ "." %s"record" ]
 
-tuple-type = "(" [ type 1*( "," type ) [ "," ] ] ")"
+tuple-type = "(" type 1*( "," type ) [ "," ] ")"
 
-type = named-type / tuple-type
+type = named-type / unit-type / tuple-type
 
 group-coordinate = ( [ "-" ] numeral ) / "+" / "-" / "_"
 
@@ -297,6 +302,7 @@ primary-expression = literal
                    / "(" expression ")"
                    / free-function-call
                    / static-function-call
+                   / unit-expression
                    / tuple-expression
                    / struct-expression
 
@@ -310,6 +316,8 @@ free-function-call = identifier function-arguments
 static-function-call = named-type "::" identifier function-arguments
 
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
+
+unit-expression = "(" ")"
 
 tuple-expression = "(" [ expression 1*( "," expression ) [ "," ] ] ")"
 


### PR DESCRIPTION
The unit type is considered a primitive type, since its (only) value is atomic, i.e. does not consist of aggregated sub-values. However, it is not a named type, because it is denoted via the symbols `(` `)` and not via an identifier or a keyword. These distinctions are reflected in the modified rules, which are more than just addint a unit type.

The unit expression is added as a primary expression.

Note that there may be whitespace and comments between the opening and closing parentheses of the unit type or expression. Even though it would be generally a discouraged practice to actually put whitespace and comments there, it seems appropriate to allow that at the grammar level. If we wanted to disallow that, we would have to add `()` as a new symbol lexeme.

Partially related to the previous point, I considered whether `()` could be a unit literal, but opted against it.