### PR TITLE
[Leo] Make return types optional.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -460,7 +460,8 @@ decrement-statement =
     %s"decrement" "(" identifier "," expression "," expression [ "," ] ")" ";"
 
 function-declaration = *annotation %s"function" identifier
-                       "(" [ function-parameters ] ")" "->" type
+                       "(" [ function-parameters ] ")"
+                       [ "->" type ]
                        block
 
 function-parameters = function-parameter *( "," function-parameter ) [ "," ]
@@ -469,7 +470,8 @@ function-parameter = [ %s"public" / %s"constant" / %s"const" ]
                      identifier ":" type
 
 transition-declaration = *annotation %s"transition" identifier
-                         "(" [ function-parameters ] ")" "->" type
+                         "(" [ function-parameters ] ")"
+                         [ "->" type ]
                          block [ finalizer ]
 
 finalizer = %s"finalize" identifier


### PR DESCRIPTION
Consistently with the current parser implementation.

This is essentially the same as https://github.com/AleoHQ/grammars/pull/7, but that one now has a conflict with the main branch, so it seems easier to make this new PR.