### PR TITLE
[Leo] Allow tuples in declarations.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -408,9 +408,14 @@ block = "{" *statement "}"
 
 return-statement = %s"return" expression ";"
 
-variable-declaration = %s"let" identifier ":" type "=" expression ";"
+variable-declaration = %s"let" identifier-or-identifiers ":" type
+                       "=" expression ";"
 
-constant-declaration = %s"const" identifier ":" type "=" expression ";"
+constant-declaration = %s"const" identifier-or-identifiers ":" type
+                       "=" expression ";"
+
+identifier-or-identifiers = identifier
+                          / "(" identifier 1*( "," identifier ) [ "," ] ")"
 
 branch = %s"if" expression block
 


### PR DESCRIPTION
Besides a single identifier, a variable or constant declaration can now have a tuple of two or more identifiers.