### PR TITLE
[Leo] Add the `private` modifier.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -110,6 +110,7 @@ keyword = %s"address"
         / %s"increment"
         / %s"let"
         / %s"mapping"
+        / %s"private"
         / %s"program"
         / %s"public"
         / %s"record"
@@ -465,17 +466,20 @@ function-declaration = *annotation %s"function" identifier
 
 function-parameters = function-parameter *( "," function-parameter ) [ "," ]
 
-function-parameter = [ %s"public" / %s"constant" / %s"const" ]
+function-parameter = [ %s"public" / %s"private" / %s"constant" / %s"const" ]
                      identifier ":" type
 
-transition-declaration = *annotation %s"transition" identifier
-                         "(" [ function-parameters ] ")" "->" type
-                         block [ finalizer ]
+transition-declaration =
+    *annotation %s"transition" identifier
+    "(" [ function-parameters ] ")"
+    "->" [ %s"public" / %s"private" / %s"constant" / %s"const" ] type
+    block [ finalizer ]
 
-finalizer = %s"finalize" identifier
-            "(" [ function-parameters ] ")"
-            [ "->" type ]
-            block
+finalizer =
+    %s"finalize" identifier
+    "(" [ function-parameters ] ")"
+    [ "->" [ %s"public" / %s"private" / %s"constant" / %s"const" ] type ]
+    block
 
 struct-declaration = %s"struct" identifier
                      "{" struct-component-declarations "}"


### PR DESCRIPTION
This is allowed in function parameters and output types of transition functions and finalizer functions (not helper functions). The grammar captures the restriction on helper function's output types, but not on helper function's parameters. It could, if we differentiated the function parameters, but it may not be worth the complication.