### PR TITLE
[Leo] Make `inline` output type optional.

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -492,7 +492,8 @@ function-parameter = [ %s"public" / %s"private" / %s"constant" ]
                      identifier ":" type
 
 inline-declaration = *annotation %s"inline" identifier
-                     "(" [ function-parameters ] ")" "->" type
+                     "(" [ function-parameters ] ")"
+                     [ "->" type ]
                      block
 
 transition-declaration =


### PR DESCRIPTION
This was an oversight in the grammar, which this PR fixes.