### PR TITLE
[Leo] Add assert function names as keywords

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -98,6 +98,9 @@ not-line-feed-or-carriage-return = horizontal-tab
                                  ; anything but <LF> and <CR>
 
 keyword = %s"address"
+        / %s"assert"
+        / %s"assert_eq"
+        / %s"assert_neq"
         / %s"bool"
         / %s"console"
         / %s"constant"


### PR DESCRIPTION
The keywords `assert`, `assert_eq` and `assert_neq` is defined as keywords in Leo compiler, but not in the grammar definition.