### PR TITLE
[Aleo ins.] Add `group::GEN` operand.

### DIFF
--- a/aleo.abnf
+++ b/aleo.abnf
@@ -206,7 +206,11 @@ literal = arithmetic-literal
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-operand = literal / register-access / %s"self.caller" / program-id
+operand = literal
+        / %s"group::GEN"
+        / register-access
+        / %s"self.caller"
+        / program-id
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
This is added to the `operand` rule (which is also now split across multiple lines), instead of the `literal` rule, to follow more closely the snarkVM parser implementation, which handles this new operand in the parser for operands, not the parser for literals.

This concerns the concrete syntax of Aleo instructions. The snarkVM parser actually turns `group::GEN` into a literal in the abstract syntax. This makes the (implicit) syntax abstraction mapping dependent on the curve used.

Matches https://github.com/AleoHQ/snarkVM/pull/1594.