### PR TITLE
[Leo] Add support for underscores in numeric literals

### DIFF
--- a/leo.abnf
+++ b/leo.abnf
@@ -149,7 +149,7 @@ decimal-digit = %x30-39   ; 0-9
 identifier = letter *( letter / decimal-digit / "_" )
              ; but not a keyword or a boolean literal or aleo1...
 
-numeral = 1*decimal-digit
+numeral = 1*( decimal-digit *"_" )
 
 unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
 

--- a/leo.abnf
+++ b/leo.abnf
@@ -151,6 +151,8 @@ identifier = letter *( letter / decimal-digit / "_" )
 
 numeral = 1*( decimal-digit *"_" )
 
+whole-number = %x30 / ( %x31-39 *( decimal-digit ) )
+
 unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
 
 signed-literal = numeral ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
@@ -300,7 +302,7 @@ postfix-expression = primary-expression
                    / struct-component-expression
                    / method-call
 
-tuple-component-expression = postfix-expression "." numeral
+tuple-component-expression = postfix-expression "." whole-number
 
 struct-component-expression = postfix-expression "." identifier
 

--- a/leo.abnf
+++ b/leo.abnf
@@ -146,6 +146,8 @@ letter = uppercase-letter / lowercase-letter
 
 decimal-digit = %x30-39   ; 0-9
 
+nonzero-decimal-digit = %x31-39   ; 1-9
+
 identifier = letter *( letter / decimal-digit / "_" )
              ; but not a keyword or a boolean literal or aleo1...
 

--- a/leo.abnf
+++ b/leo.abnf
@@ -151,7 +151,7 @@ identifier = letter *( letter / decimal-digit / "_" )
 
 numeral = 1*( decimal-digit *"_" )
 
-whole-number = %x30 / ( %x31-39 *( decimal-digit ) )
+tuple-index = "0" / nonzero-decimal-digit *( decimal-digit )
 
 unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
 
@@ -302,7 +302,7 @@ postfix-expression = primary-expression
                    / struct-component-expression
                    / method-call
 
-tuple-component-expression = postfix-expression "." whole-number
+tuple-component-expression = postfix-expression "." tuple-index
 
 struct-component-expression = postfix-expression "." identifier
 


### PR DESCRIPTION
As detailed in [Leo PR](https://github.com/AleoHQ/leo/issues/2538) want to allow numbers like `1_000_000u32` to exist. This is similar to the [Aleo grammar](https://github.com/AleoHQ/grammars/blob/1e3c08275395f1afb733dde78aaddd727eeebbcd/aleo.abnf#L177C1-L177C1) and [Rust](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=554372f372214b10c2d4bc8783d194c0).